### PR TITLE
Retailervalues

### DIFF
--- a/app/controllers/retailers_controller.rb
+++ b/app/controllers/retailers_controller.rb
@@ -27,7 +27,7 @@ def create
 end
 
 def retailer_params
-      params.require(:retailer).permit(:name, :paypalID, :contact_email, :phone, :address, :city, :state, :zip, :split)
+      params.require(:retailer).permit(:name, :paypalID, :contact_email, :phone, :address, :city, :state, :zip, :fee_split, :cause_split, :user_split)
     end
 
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -13,6 +13,7 @@ class TransactionsController < ApplicationController
   end
 
   def show
+    @transaction.cause_id = current_user.cause_id
   end
 
   def edit
@@ -27,23 +28,19 @@ class TransactionsController < ApplicationController
   end
 
   def create
-    # Find retailer and cause names and save their ids to the transaction table
+    # Find retailer name in the retailer table by entered value and save its id to the transaction table
     params[:transaction][:retailer_id] = Retailer.find_by_name(params[:retailer_name])[:id]
-    params[:transaction][:cause_id] = Cause.find_by_name(params[:cause_name])[:id]
-    # Find retailer and cause splits by entered names and save their split values to the transaction table
-    params[:transaction][:retailer_split] = Retailer.find_by_name(params[:retailer_name])[:split]
-    params[:transaction][:cause_split] = Cause.find_by_name(params[:cause_name])[:split]
-    # Create a defaults object from the defaults table
-    @defaults = Default.new
-    @defaults = Default.first
+    # Find splits in retailer table by entered retailer name and save their split values to the transaction table
+    params[:transaction][:retailer_split] = Retailer.find_by_name(params[:retailer_name])[:user_split]
+    params[:transaction][:cause_split] = Retailer.find_by_name(params[:retailer_name])[:cause_split]
+    params[:transaction][:fee_split] = Retailer.find_by_name(params[:retailer_name])[:fee_split]
     # Create a Transaction object
     @transaction = Transaction.new(transaction_params)
     # Set the transaction user_id = to the logged in user, and save the username to the transaction (transaction.user_id)
     if @transaction.save
-      # save fee_split value from the Defaults table to the transaction's fee_split field
-      @transaction.fee_split = @defaults.fee_split
       # save value from current signed in user to transaction's user_id field
       @transaction.user_id = current_user.id
+      @transaction.cause_id = current_user.cause_id
     end
 
     respond_to do |format|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
 	end
 
 	def create
-	@user = User.new(user_params)
+	@user = User.new
 
 		respond_to do |format|
 	      if @user.save
@@ -26,8 +26,5 @@ class UsersController < ApplicationController
 	    end
 	end
 
-	def retailer_params
-      params.require(:user).permit(:username, :cause_id, :paypalID, :street_address, :city, :state, :zip, :phone, :email, :encrypted_password)
-    end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,9 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
 
-  def index
+	def index
   	@users = User.all
-  	end
+	end
 
 	def new
     @user = User.new
@@ -13,6 +13,21 @@ class UsersController < ApplicationController
 	end
 
 	def create
+	@user = User.new(user_params)
+
+		respond_to do |format|
+	      if @user.save
+	        format.html { redirect_to '/onboarding', notice: 'User was successfully created.' }
+	        format.json { render :show, status: :created, location: @user }
+	      else
+	        format.html { render :new }
+	        format.json { render json: @user.errors, status: :unprocessable_entity }
+	      end
+	    end
 	end
+
+	def retailer_params
+      params.require(:user).permit(:username, :cause_id, :paypalID, :street_address, :city, :state, :zip, :phone, :email, :encrypted_password)
+    end
 
 end

--- a/app/models/cause.rb
+++ b/app/models/cause.rb
@@ -1,3 +1,8 @@
 class Cause < ActiveRecord::Base
   has_many :users
+
+  validates_presence_of :name, :message => "Cause name must be entered."
+  validates_presence_of :paypalID, :message => "Pay pal ID must be entered."
+  validates_presence_of :zip, :message => "Zip code must be entered."
+
 end

--- a/app/models/retailer.rb
+++ b/app/models/retailer.rb
@@ -1,3 +1,10 @@
 class Retailer < ActiveRecord::Base
   has_many :transactions
+
+  validates_presence_of :name, :message => "for retailer must be entered."
+  validates_presence_of :paypalID, :message => "ID must be entered."
+  validates_presence_of :zip, :message => "code must be entered."
+  validates_presence_of :fee_split, :message => "for Dig In must be entered."
+  validates_presence_of :cause_split, :message => "for Cause must be entered."
+  validates_presence_of :user_split, :message => "for User must be entered."
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -15,7 +15,6 @@ class Transaction < ActiveRecord::Base
   validates_presence_of :retailer_split, :message => "Retailer split decimal must be entered."
   validates_presence_of :cause_split, :message => "Cause split decimal must be entered."
   validates_presence_of :retailer_id, :message => "Retailer name must be entered."
-  validates_presence_of :cause_id, :message => "Cause name must be entered."
   validates_presence_of :transaction_date, :message => "Transaction date must be entered."
   validates_numericality_of :amount, :only_decimal => true, message: "%{value} is not a valid dollar amount in Transaction Amount."
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -12,11 +12,7 @@ class Transaction < ActiveRecord::Base
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
 
   validates_presence_of :image, :message => "needs to be uploaded. Please upload your receipt."
-  validates_presence_of :retailer_split, :message => "Retailer split decimal must be entered."
-  validates_presence_of :cause_split, :message => "Cause split decimal must be entered."
   validates_presence_of :retailer_id, :message => "Retailer name must be entered."
   validates_presence_of :transaction_date, :message => "Transaction date must be entered."
   validates_numericality_of :amount, :only_decimal => true, message: "%{value} is not a valid dollar amount in Transaction Amount."
-
-
 end

--- a/app/views/causes/new.html.erb
+++ b/app/views/causes/new.html.erb
@@ -29,42 +29,39 @@
     </div>
    <% end %>
   <p>
-    Cause Name
+    Cause Name<br>
     <%= f.text_field(:name) %>
   </p>
   <br>
   <p>
-    Contact Email
+    Contact Email<br>
     <%= f.email_field(:contact_email) %>
   </p>
   <br>
-  <p>Paypal ID
+  <p>Paypal ID<br>
     <%= f.text_field(:paypalID) %>
   </p>
   <br>
   <p>
-    Address
+    Address<br>
     <%= f.text_field(:address) %>
   </p>
   <br>
   <p>
-    City
+    City<br>
     <%= f.text_field(:city) %></p>
     <br>
-    <p> State <%= f.text_field(:state) %>
+    <p> State <br>
+      <%= f.text_field(:state) %>
      </p>
      <br>
-<p> Zip <%= f.number_field(:zip) %>
+<p> Zip<br>
+   <%= f.number_field(:zip) %>
   </p>
   <br>
   <p>
-    Phone
+    Phone<br>
     <%= f.number_field(:phone) %>
-  </p>
-  <br>
-  <p>
-    Cause Split
-    <%= text_field(:cause, :split) %>
   </p>
   <br>
 <br>

--- a/app/views/onboarding/index.html.erb
+++ b/app/views/onboarding/index.html.erb
@@ -136,7 +136,7 @@
 
 <a href="retailers/new" class="btn btn-primary btn-lg active" role="button">New Retailer</a>
 <a href="causes/new" class="btn btn-primary btn-lg active" role="button">New Cause</a>
-<a href="/users/sign_up" class="btn btn-primary btn-lg active" role="button">New User</a>
+<a href="/users/new" class="btn btn-primary btn-lg active" role="button">New User</a>
 
 <%= yield %>
 

--- a/app/views/onboarding/index.html.erb
+++ b/app/views/onboarding/index.html.erb
@@ -145,7 +145,7 @@
 <hr>
 <hr>
 <%= link_to 'Home', "/" %> | <%= link_to 'New Transaction', new_transaction_path %> | 
-<%= link_to 'Transactions Admin', "/transactions" %>
+<%= link_to 'Transaction Processing', "/transactions" %> | <%= link_to 'Database Admin', "/admin" %>
 <br><br>
 
 </div>

--- a/app/views/retailers/new.html.erb
+++ b/app/views/retailers/new.html.erb
@@ -29,42 +29,54 @@
     </div>
    <% end %>
   <p>
-    Retailer Name
+    Retailer Name <br>
     <%= f.text_field(:name) %>
   </p>
   <br>
   <p>
-    Contact Email
+    Contact Email <br>
     <%= f.email_field(:contact_email) %>
   </p>
   <br>
-  <p>Paypal ID
+  <p>Paypal ID<br>
     <%= f.text_field(:paypalID) %>
   </p>
   <br>
   <p>
-    Address
+    Address<br>
     <%= f.text_field(:address) %>
   </p>
   <br>
   <p>
-    City
+    City<br>
     <%= f.text_field(:city) %></p>
     <br>
-    <p> State <%= f.text_field(:state) %>
+    <p> State<br>
+     <%= f.text_field(:state) %>
      </p>
      <br>
-<p> Zip <%= f.number_field(:zip) %>
+<p> Zip <br>
+  <%= f.number_field(:zip) %>
   </p>
   <br>
   <p>
-    Phone
+    Phone<br>
     <%= f.number_field(:phone) %>
   </p>
   <br>
   <p>
-    Retailer Split
-    <%= text_field(:retailer, :split) %>
+    Fee Split decimal (to Dig In)<br>
+    <%= text_field(:retailer, :fee_split) %>
+  </p>
+  <br>
+  <p>
+    Cause Split decimal (donation to the Cause)<br>
+    <%= text_field(:retailer, :cause_split) %>
+  </p>
+  <br>
+  <p>
+    User Split decimal (cash back to the User)<br>
+    <%= text_field(:retailer, :fee_split) %>
   </p>
   <br>
 <br>

--- a/app/views/retailers/new.html.erb
+++ b/app/views/retailers/new.html.erb
@@ -66,17 +66,17 @@
   <br>
   <p>
     Fee Split decimal (to Dig In)<br>
-    <%= text_field(:retailer, :fee_split) %>
+    <%= f.number_field(:fee_split) %>
   </p>
   <br>
   <p>
     Cause Split decimal (donation to the Cause)<br>
-    <%= text_field(:retailer, :cause_split) %>
+    <%= f.number_field(:cause_split) %>
   </p>
   <br>
   <p>
     User Split decimal (cash back to the User)<br>
-    <%= text_field(:retailer, :fee_split) %>
+    <%= f.number_field(:user_split) %>
   </p>
   <br>
 <br>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -12,7 +12,6 @@
 <!-- UPDATE NOTICE -->
 <p> Welcome admin (<%= current_admin.email %>), and user (<%= current_user.username %>). <%= notice %></p>
 <!-- Login Menu -->
-<p><%= link_to 'Home', "/" %> | <%= link_to 'New Transaction', new_transaction_path %></p>
 <%= yield %>
 <br>
 <!-- ACCORDION INITIALIZE -->
@@ -190,7 +189,7 @@
 
 <hr>
 <%= link_to 'Home', "/" %> | <%= link_to 'New Transaction', new_transaction_path %> | 
-<%= link_to 'Onboarding', "/onboarding" %>
+<%= link_to 'Onboarding', "/onboarding" %> | <%= link_to 'Database Admin', "/admin" %>
 <br>
 <%= yield %>
 <br>
@@ -205,8 +204,7 @@
 <div class="container">
 You are not authorized to view this page.  You must be logged in as an admin and a user to continue.
 <hr>
-<%= link_to 'Home', "/" %> | <%= link_to 'New Transaction', new_transaction_path %> | 
-<%= link_to 'Onboarding', "/onboarding" %>
+<%= link_to 'Home', "/" %>
   <% end %>
 
 <br>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -52,8 +52,8 @@
     Retailer Name <input id="retailer_search", type="text", name="retailer_name">
   </p>
 <br>
-<p>Cause Name <%= text_field_tag 'cause_name', @transaction.cause.name %></p>
-<br>
+<p>Your account is set to donate to: <b><%= @transaction.cause.name %></b>
+<br><br>
   <p>
     Upload Receipt Image
     <%= f.file_field :image %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="/resources/demos/style.css">
+
+</head>
+<body>
+
+<div class="jumbotron">
+      <div class="container">
+        <h1>Onboarding</h1>
+        <p> You are onboarding a new user. <%= notice %></p>
+      </div>
+    </div>
+
+<div class="container">
+<%= form_for @user do |f| %>
+  <% if @user.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@transaction.errors.count, "error") %> prohibited this transaction from being saved:</h2>
+      <ul>
+      <% @transaction.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+   <% end %>
+
+<div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div><br>
+
+  <div class="field">
+    <%= f.label :username %><br />
+    <%= f.text_field :username %>
+  </div><br>
+
+  <div class="field">
+    <%= f.label :password %>
+    <% if @minimum_password_length %>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <% end %><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div><br>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "off" %>
+  </div><br>
+
+  <div class="field">
+  <strong>Select a cause</strong><br />
+  <%= f.select(:cause_id) do %><br />
+  <%= options_from_collection_for_select(Cause.all, :id, :name) %>
+  <% end %>
+  <br>You can change this later.<br>
+  If your preferred cause is not listed, they have not signed up.<br>
+  Select one of the causes above and ask them to sign up at http://rewards.digin.club
+  </div><br>
+
+  <div class="actions">
+    <%= f.submit "Sign Up" %>
+  </div><br>
+
+<% end %>
+
+
+
+</div>
+
+<br>
+<br>
+
+<%= yield %>
+
+</body>
+
+<hr>
+
+</html>
+
+

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,1 @@
+THE SHOW VIEW

--- a/db/migrate/20160401004058_retailer_split_fields.rb
+++ b/db/migrate/20160401004058_retailer_split_fields.rb
@@ -1,0 +1,7 @@
+class RetailerSplitFields < ActiveRecord::Migration
+  def change
+  	rename_column("retailers", "split", "fee_split")
+  	add_column :retailers, :cause_split, :decimal, precision: 5, scale: 2
+  	add_column :retailers, :user_split, :decimal, precision: 5, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160330190101) do
+ActiveRecord::Schema.define(version: 20160401004058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,7 +64,9 @@ ActiveRecord::Schema.define(version: 20160330190101) do
     t.string   "zip",           limit: 5
     t.string   "phone",         limit: 10
     t.string   "contact_email"
-    t.decimal  "split",                    precision: 5, scale: 2
+    t.decimal  "fee_split",                precision: 5, scale: 2
+    t.decimal  "cause_split",              precision: 5, scale: 2
+    t.decimal  "user_split",               precision: 5, scale: 2
   end
 
   create_table "transactions", force: :cascade do |t|


### PR DESCRIPTION
Rearranged the way transaction splits are pulled from the system.  We realized after on boarding a few clients that the splits needed to be specified by the retailer for the cause and the user.  So, this required a re-organization of the views and code for database lookup and saving.  The split values are now pulled and changed from the RETAILERS table.

In this branch, I also pulled out the typeahead for the cause.  It was decided that we didn't want the user to have the option to change their cause in the transaction view.  We may decide to create a place for the user to change their default cause in the future.  For now, if it needs to be changed the user will need to contact us.

This branch will require a rake db:migrate, but should not affect any table data.  For any existing retailers in your database, split values must be filled in or the app will not function properly.  
